### PR TITLE
chore: Cleanup the temp download dir if it is empty after download error.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -555,8 +555,9 @@ app.post('/extract', [
               log.error(lgParams, err);
               throw err;
             } finally {
+              // Clean up!
+              await context.close();
               // Disconnect from Puppeteer process.
-              //await context.close();
               await browser.disconnect();
             }
           });

--- a/app/app.js
+++ b/app/app.js
@@ -542,7 +542,8 @@ app.post('/extract', [
                       break;
                   } catch (error) {
                     log.error(lgParams, `Failed to download from link: ${pdfLink}`, error);
-                    // Try to remove the download directory. If it is not empty, this will fail, so log that.
+                    // Try to remove the download directory.
+                    // If it is not empty, this will fail, so log that.
                     try {
                       fs.rmdirSync(downloadPath);
                     } catch (error) {

--- a/app/app.js
+++ b/app/app.js
@@ -541,7 +541,13 @@ app.post('/extract', [
                       // Exit the loop after downloading the first valid link.
                       break;
                   } catch (error) {
-                      log.error(lgParams, `Failed to download from link: ${pdfLink}`, error);
+                    log.error(lgParams, `Failed to download from link: ${pdfLink}`, error);
+                    // Try to remove the download directory. If it is not empty, this will fail, so log that.
+                    try {
+                      fs.rmdirSync(downloadPath);
+                    } catch (error) {
+                      log.error(lgParams, `Unable to remove download directory: ${downloadPath}`, error);
+                    }
                   }
                 }
               }


### PR DESCRIPTION
Otherwise each failure will leave an empty directory under /tmp and that gets messy. If there was an error *but* a file was downoaded, this will not remove the dir.